### PR TITLE
feat(cvsb-19924): added validation to open visit ep query param

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ node_modules
 .reports
 coverage
 vscode
+handler.ts

--- a/src/functions/openVisitCheck.ts
+++ b/src/functions/openVisitCheck.ts
@@ -7,7 +7,7 @@ import { HTTPRESPONSE } from '../assets/enums';
 const openVisitCheck: Handler = async (event: any): Promise<any> => {
   const staffID = event.queryStringParameters?.testerStaffId;
 
-  if (!staffID) {
+  if (!staffID || staffID.trim().length === 0 || staffID === 'undefined' || staffID === 'null') {
     return new HTTPResponse(400, HTTPRESPONSE.BAD_REQUEST);
   }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -3,6 +3,7 @@ import { APIGatewayProxyResult, Callback, Context, Handler } from 'aws-lambda';
 import Path from 'path-parser';
 import { Configuration, IFunctionEvent } from './utils/Configuration';
 import { HTTPResponse } from './utils/HTTPResponse';
+import { ILogMessage } from './models/ILogMessage';
 
 const handler: Handler = async (
   event: any,
@@ -56,7 +57,12 @@ const handler: Handler = async (
 
     Object.assign(event, { pathParameters: lambdaPathParams });
 
-    console.log(`HTTP ${event.httpMethod} ${event.path} -> λ ${lambdaEvent.name}`);
+    const logMessage: ILogMessage = {
+      HTTP: `${event.httpMethod} ${event.path} -> λ ${lambdaEvent.name}`,
+      PATH_PARAMS: `${JSON.stringify(event.pathParameters)}`,
+      QUERY_PARAMS: `${JSON.stringify(event.queryStringParameters)}`};
+
+    console.log(logMessage);
 
     // Explicit conversion because typescript can't figure it out
     return lambdaFn(event, context, callback) as Promise<APIGatewayProxyResult>;

--- a/src/models/ILogMessage.ts
+++ b/src/models/ILogMessage.ts
@@ -1,0 +1,5 @@
+export interface ILogMessage {
+  HTTP?: string;
+  PATH_PARAMS?: string;
+  QUERY_PARAMS?: string;
+}

--- a/src/utils/HTTPResponse.ts
+++ b/src/utils/HTTPResponse.ts
@@ -25,6 +25,8 @@ class HTTPResponse extends Error implements APIGatewayProxyResult {
 
     this.statusCode = statusCode;
     this.body = JSON.stringify(body);
+
+    console.log(`HTTP STATUS CODE RETURNED: ${this.statusCode}`);
   }
 }
 

--- a/tests/unit/openVisitCheckFunction.unitTest.ts
+++ b/tests/unit/openVisitCheckFunction.unitTest.ts
@@ -22,6 +22,91 @@ describe('openVisitCheck Function', () => {
       expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
     });
   });
+  describe('with staffId query param that is empty string', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: ' '
+        }
+      };
+      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
+  describe('with staffId query param that is the string "undefined"', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: 'undefined'
+        }
+      };
+      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
+  describe('with staffId query param that is the string "null"', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: 'null'
+        }
+      };
+      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
+  describe('with staffId query param that is undefined', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: undefined
+        }
+      };
+      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
+  describe('with staffId query param that is null', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: null
+        }
+      };
+      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
   describe('with staffId query param', () => {
     describe('and with a successful return from the Service call', () => {
       it('returns 200 and the data from the service call', async () => {

--- a/tests/unit/openVisitCheckFunction.unitTest.ts
+++ b/tests/unit/openVisitCheckFunction.unitTest.ts
@@ -29,7 +29,6 @@ describe('openVisitCheck Function', () => {
           testerStaffId: ' '
         }
       };
-      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
       expect.assertions(2);
 
       const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
@@ -46,7 +45,6 @@ describe('openVisitCheck Function', () => {
           testerStaffId: 'undefined'
         }
       };
-      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
       expect.assertions(2);
 
       const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
@@ -63,7 +61,6 @@ describe('openVisitCheck Function', () => {
           testerStaffId: 'null'
         }
       };
-      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
       expect.assertions(2);
 
       const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
@@ -80,7 +77,6 @@ describe('openVisitCheck Function', () => {
           testerStaffId: undefined
         }
       };
-      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
       expect.assertions(2);
 
       const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
@@ -97,7 +93,6 @@ describe('openVisitCheck Function', () => {
           testerStaffId: null
         }
       };
-      // const svcSpy = jest.spyOn(OpenVisitService.prototype, "checkOpenVisit").mockResolvedValue(true)
       expect.assertions(2);
 
       const output: HTTPResponse = await openVisitCheck(event, ctx, () => {


### PR DESCRIPTION
## Check if testerId is present when receiving a call to search for an open visit

This story involved updating the open visit endpoint logic to ensure that in the event null, defined, " ", "null" or "undefined" are provided as a query parameter, then the appropriate 400 bad request is returned. Logging has also been improved and now includes the path/query parameters, in addition to the http method call.
[link to ticket number](https://jira.dvsacloud.uk/browse/CVSB-19924)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
