### PR TITLE
VTA-300: Updated openActivity function (including vta-470 endActivity function)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ node_modules
 .reports
 coverage
 vscode
+handler.ts

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-i": "npm run test:integration -- --globalSetup='./scripts/setUp.ts' --globalTeardown='./scripts/tearDown.ts'",
     "test:integration": "BRANCH=local jest --testMatch=\"**/*.intTest.ts\" --runInBand",
     "prepush": "npm run coverage && npm run build && npm run test-i",
-    "security-checks": "git secrets --scan && git log -p | scanrepo",
+    "security-checks": "git secrets --scan",
     "lint": "tslint --fix src/**/*.ts tests/**/*.ts",
     "format": "prettier --write .",
     "sonar-scanner": "sonar-scanner",

--- a/src/functions/endActivity.ts
+++ b/src/functions/endActivity.ts
@@ -2,13 +2,20 @@ import { APIGatewayProxyResult, Context, Handler } from 'aws-lambda';
 import { ActivityService } from '../services/ActivityService';
 import { HTTPResponse } from '../utils/HTTPResponse';
 import { DynamoDBService } from '../services/DynamoDBService';
+import { HTTPRESPONSE } from '../assets/enums';
+import { Validator } from '../utils/Validator';
 
 const endActivity: Handler = async (
   event: any,
   context: Context
 ): Promise<APIGatewayProxyResult> => {
   const activityService = new ActivityService(new DynamoDBService());
+  const check: Validator = new Validator();
   const id: string = event.pathParameters.id;
+
+  if (!check.parameterIsValid(id)) {
+    return new HTTPResponse(400, HTTPRESPONSE.BAD_REQUEST);
+  }
 
   return activityService
     .endActivity(id)

--- a/src/functions/openVisitCheck.ts
+++ b/src/functions/openVisitCheck.ts
@@ -3,11 +3,13 @@ import { HTTPResponse } from '../utils/HTTPResponse';
 import { DynamoDBService } from '../services/DynamoDBService';
 import OpenVisitService from '../services/OpenVisitService';
 import { HTTPRESPONSE } from '../assets/enums';
+import { Validator } from '../utils/Validator';
 
 const openVisitCheck: Handler = async (event: any): Promise<any> => {
+  const check: Validator = new Validator();
   const staffID = event.queryStringParameters?.testerStaffId;
 
-  if (!staffID) {
+  if (!check.parameterIsValid(staffID)) {
     return new HTTPResponse(400, HTTPRESPONSE.BAD_REQUEST);
   }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -3,6 +3,7 @@ import { APIGatewayProxyResult, Callback, Context, Handler } from 'aws-lambda';
 import Path from 'path-parser';
 import { Configuration, IFunctionEvent } from './utils/Configuration';
 import { HTTPResponse } from './utils/HTTPResponse';
+import { ILogMessage } from './models/ILogMessage';
 
 const handler: Handler = async (
   event: any,
@@ -56,7 +57,13 @@ const handler: Handler = async (
 
     Object.assign(event, { pathParameters: lambdaPathParams });
 
-    console.log(`HTTP ${event.httpMethod} ${event.path} -> λ ${lambdaEvent.name}`);
+    const logMessage: ILogMessage = {
+      HTTP: `${event.httpMethod} ${event.path} -> λ ${lambdaEvent.name}`,
+      PATH_PARAMS: `${JSON.stringify(event.pathParameters)}`,
+      QUERY_PARAMS: `${JSON.stringify(event.queryStringParameters)}`
+    };
+
+    console.log(logMessage);
 
     // Explicit conversion because typescript can't figure it out
     return lambdaFn(event, context, callback) as Promise<APIGatewayProxyResult>;

--- a/src/models/ILogMessage.ts
+++ b/src/models/ILogMessage.ts
@@ -1,0 +1,5 @@
+export interface ILogMessage {
+  HTTP?: string;
+  PATH_PARAMS?: string;
+  QUERY_PARAMS?: string;
+}

--- a/src/utils/HTTPResponse.ts
+++ b/src/utils/HTTPResponse.ts
@@ -25,6 +25,8 @@ class HTTPResponse extends Error implements APIGatewayProxyResult {
 
     this.statusCode = statusCode;
     this.body = JSON.stringify(body);
+
+    console.log(`HTTP STATUS CODE RETURNED: ${this.statusCode}`);
   }
 }
 

--- a/src/utils/Validator.ts
+++ b/src/utils/Validator.ts
@@ -1,0 +1,15 @@
+export class Validator {
+  // tslint:disable-next-line: no-empty
+  public constructor() {}
+
+  /**
+   * Validate query or path parameter provided in the request
+   * @param parameter Query or path parameter provided
+   * @returns boolean Result of logic determining validity
+   */
+  public parameterIsValid(parameter: string): boolean {
+    return parameter
+      ? parameter.trim().length !== 0 && parameter !== 'undefined' && parameter !== 'null'
+      : false;
+  }
+}

--- a/tests/unit/endActivityFunction.unitTest.ts
+++ b/tests/unit/endActivityFunction.unitTest.ts
@@ -2,6 +2,7 @@ import { endActivity } from '../../src/functions/endActivity';
 import { ActivityService } from '../../src/services/ActivityService';
 import mockContext from 'aws-lambda-mock-context';
 import { HTTPResponse } from '../../src/utils/HTTPResponse';
+import { HTTPRESPONSE } from '../../src/assets/enums';
 
 describe('endActivity Function', () => {
   context('calls activity service', () => {
@@ -11,7 +12,7 @@ describe('endActivity Function', () => {
         ActivityService.prototype.endActivity = jest
           .fn()
           .mockResolvedValue({ wasVisitAlreadyClosed: false });
-        const resp: HTTPResponse = await endActivity({ pathParameters: { id: 1 } }, ctx, () => {
+        const resp: HTTPResponse = await endActivity({ pathParameters: { id: '1' } }, ctx, () => {
           return;
         });
         expect(resp).toBeInstanceOf(HTTPResponse);
@@ -24,12 +25,83 @@ describe('endActivity Function', () => {
       it('returns the thrown  error', async () => {
         ActivityService.prototype.endActivity = jest.fn().mockRejectedValue(new Error('Oh No!'));
         try {
-          await endActivity({ pathParameters: { id: 1 } }, ctx, () => {
+          await endActivity({ pathParameters: { id: '1' } }, ctx, () => {
             return;
           });
         } catch (e) {
           expect(e.message).toEqual('Oh No!');
         }
+      });
+      it('returns BAD REQUEST error when path parameter is an empty string', async () => {
+        ActivityService.prototype.endActivity = jest
+          .fn()
+          .mockResolvedValue({ wasVisitAlreadyClosed: false });
+        const resp: HTTPResponse = await endActivity({ pathParameters: { id: ' ' } }, ctx, () => {
+          return;
+        });
+        expect(resp).toBeInstanceOf(HTTPResponse);
+        expect(resp.statusCode).toEqual(400);
+        expect(resp.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+      });
+      it('returns BAD REQUEST error when path parameter is the string "undefined"', async () => {
+        ActivityService.prototype.endActivity = jest
+          .fn()
+          .mockResolvedValue({ wasVisitAlreadyClosed: false });
+        const resp: HTTPResponse = await endActivity(
+          { pathParameters: { id: 'undefined' } },
+          ctx,
+          () => {
+            return;
+          }
+        );
+        expect(resp).toBeInstanceOf(HTTPResponse);
+        expect(resp.statusCode).toEqual(400);
+        expect(resp.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+      });
+      it('returns BAD REQUEST error when path parameter is the string "null"', async () => {
+        ActivityService.prototype.endActivity = jest
+          .fn()
+          .mockResolvedValue({ wasVisitAlreadyClosed: false });
+        const resp: HTTPResponse = await endActivity(
+          { pathParameters: { id: 'null' } },
+          ctx,
+          () => {
+            return;
+          }
+        );
+        expect(resp).toBeInstanceOf(HTTPResponse);
+        expect(resp.statusCode).toEqual(400);
+        expect(resp.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+      });
+      it('returns BAD REQUEST error when path parameter is undefined', async () => {
+        ActivityService.prototype.endActivity = jest
+          .fn()
+          .mockResolvedValue({ wasVisitAlreadyClosed: false });
+        const resp: HTTPResponse = await endActivity(
+          { pathParameters: { id: undefined } },
+          ctx,
+          () => {
+            return;
+          }
+        );
+        expect(resp).toBeInstanceOf(HTTPResponse);
+        expect(resp.statusCode).toEqual(400);
+        expect(resp.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+      });
+      it('returns BAD REQUEST error when path parameter is null', async () => {
+        ActivityService.prototype.endActivity = jest
+          .fn()
+          .mockResolvedValue({ wasVisitAlreadyClosed: false });
+        const resp: HTTPResponse = await endActivity(
+          { pathParameters: { id: undefined } },
+          ctx,
+          () => {
+            return;
+          }
+        );
+        expect(resp).toBeInstanceOf(HTTPResponse);
+        expect(resp.statusCode).toEqual(400);
+        expect(resp.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
       });
     });
   });

--- a/tests/unit/openVisitCheckFunction.unitTest.ts
+++ b/tests/unit/openVisitCheckFunction.unitTest.ts
@@ -22,6 +22,86 @@ describe('openVisitCheck Function', () => {
       expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
     });
   });
+  describe('with staffId query param that is empty string', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: ' '
+        }
+      };
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
+  describe('with staffId query param that is the string "undefined"', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: 'undefined'
+        }
+      };
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
+  describe('with staffId query param that is the string "null"', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: 'null'
+        }
+      };
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
+  describe('with staffId query param that is undefined', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: undefined
+        }
+      };
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
+  describe('with staffId query param that is null', () => {
+    it('return BAD REQUEST error', async () => {
+      const event = {
+        queryStringParameters: {
+          testerStaffId: null
+        }
+      };
+      expect.assertions(2);
+
+      const output: HTTPResponse = await openVisitCheck(event, ctx, () => {
+        return;
+      });
+      expect(output.statusCode).toEqual(400);
+      expect(output.body).toEqual(JSON.stringify(HTTPRESPONSE.BAD_REQUEST));
+    });
+  });
   describe('with staffId query param', () => {
     describe('and with a successful return from the Service call', () => {
       it('returns 200 and the data from the service call', async () => {


### PR DESCRIPTION
## VTA-300: Check testerId is present on openVisit endpoint

The feature branch includes the changes for both VTA-300 and VTA-470. I have added validation to both the openVisitCheck endpoint and endActivity endpoints, to ensure a valid query/path parameter is provided when calling the endpoint. If invalid, 400 bad request is returned.

[VTA-300](https://jira.dvsacloud.uk/browse/VTA-300)
[VTA-470](https://jira.dvsacloud.uk/browse/VTA-470)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [X] Squashed commit contains the JIRA ticket number
