### PR TITLE
VTA-496: Allow empty string in test station email address

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-i": "npm run test:integration -- --globalSetup='./scripts/setUp.ts' --globalTeardown='./scripts/tearDown.ts'",
     "test:integration": "BRANCH=local jest --testMatch=\"**/*.intTest.ts\" --runInBand",
     "prepush": "npm run coverage && npm run build && npm run test-i",
-    "security-checks": "git secrets --scan",
+    "security-checks": "git secrets --scan && git log -p | scanrepo",
     "lint": "tslint --fix src/**/*.ts tests/**/*.ts",
     "format": "prettier --write .",
     "sonar-scanner": "sonar-scanner",

--- a/src/models/ActivitySchema.ts
+++ b/src/models/ActivitySchema.ts
@@ -7,7 +7,7 @@ export const ActivitySchema = Joi.object().keys({
   activityType: Joi.any().only([activitiesTypes]).required(),
   testStationName: Joi.string().required(),
   testStationPNumber: Joi.string().required(),
-  testStationEmail: Joi.string().email().required(),
+  testStationEmail: Joi.string().email().required().allow(""),
   testStationType: Joi.any().only([stationTypes]).required(),
   testerName: Joi.string().min(1).max(60).required(),
   testerStaffId: Joi.string().required(),


### PR DESCRIPTION
## Handle blank test station email address in Visit and ATF Report Process

As test stations become mastered in Dynamics, VTM will load the test-station data into the VTA dynamo table, but an email address is not mandatory.  Amended validation schema to allow for empty strings to be provided.
[https://jira.dvsacloud.uk/browse/VTA-496]()

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
