### PR TITLE
VTA-737:Allow POTF testStationTypes to be used when starting visit in VTA

### DIFF
--- a/docs/activities-api.yml
+++ b/docs/activities-api.yml
@@ -242,6 +242,7 @@ components:
             - atf
             - gvts
             - hq
+            - potf
         testerName:
           type: string
         testerStaffId:

--- a/src/assets/enums.ts
+++ b/src/assets/enums.ts
@@ -41,5 +41,6 @@ export enum ActivityType {
 export enum StationType {
   ATF = 'atf',
   GVTS = 'gvts',
-  HQ = 'hq'
+  HQ = 'hq',
+  POTF = 'potf'
 }

--- a/src/models/Activity.ts
+++ b/src/models/Activity.ts
@@ -7,7 +7,7 @@ export const waitReasons: string[] = [
   'Site issue',
   'Other'
 ];
-export const stationTypes: string[] = [StationType.ATF, StationType.GVTS, StationType.HQ];
+export const stationTypes: string[] = [StationType.ATF, StationType.GVTS, StationType.HQ, StationType.POTF];
 export const activitiesTypes: string[] = [
   ActivityType.VISIT,
   ActivityType.WAIT,

--- a/tests/unit/createActivities.unitTest.ts
+++ b/tests/unit/createActivities.unitTest.ts
@@ -224,7 +224,7 @@ describe('createActivity', () => {
         expect.assertions(1);
         return activityService.createActivity(payload).catch((error: HTTPResponse) => {
           const body: any = JSON.parse(error.body);
-          expect(body.error).toEqual('"testStationType" must be one of [atf, gvts, hq]');
+          expect(body.error).toEqual('"testStationType" must be one of [atf, gvts, hq, potf]');
         });
       });
     });
@@ -294,6 +294,38 @@ describe('createActivity', () => {
       testStationPNumber: '87-1369569',
       testStationEmail: 'teststationname@dvsa.gov.uk',
       testStationType: 'gvts',
+      testerName: 'Gica',
+      testerEmail: 'tester@dvsa.gov.uk',
+      testerStaffId: '132'
+    };
+
+    it('should return a uuid', () => {
+      DynamoDBService.prototype.getOngoingByStaffId = jest.fn().mockResolvedValue({ Count: 0 });
+      DynamoDBService.prototype.put = jest
+        .fn()
+        .mockResolvedValue({ id: '00000000-0000-0000-0000-0000000000000' });
+      const activityService = new ActivityService(new DynamoDBService());
+      expect.assertions(1);
+      return activityService
+        .createActivity(payload)
+        .then((result: { id: string }) => {
+          expect(result.id).toMatch(
+            /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
+          );
+        })
+        .catch((e) => {
+          console.log('Error', e);
+        });
+    });
+  });
+
+  context("when the payload is correct for 'potf' testStationType", () => {
+    const payload: any = {
+      activityType: 'visit',
+      testStationName: 'Rowe, Wunsch and Wisoky',
+      testStationPNumber: '87-1369569',
+      testStationEmail: 'teststationname@dvsa.gov.uk',
+      testStationType: 'potf',
       testerName: 'Gica',
       testerEmail: 'tester@dvsa.gov.uk',
       testerStaffId: '132'


### PR DESCRIPTION
## Allow POTF testStationTypes to be used when starting visit in VTA

Update the service to allow potf testStationType to be used when starting a visit.
[https://dvsa.atlassian.net/browse/VTA-737](VTA-737)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
